### PR TITLE
compare against correct value in DNA check

### DIFF
--- a/src/player/it_music.c
+++ b/src/player/it_music.c
@@ -1418,7 +1418,7 @@ AllocateChannel6:
 
 		// Same note/sample/inst?
 		// ("else else" is 0x36 --GM)
-		if(dh != (bp == 0x32 ? slave->Nte : bp == 0x33 ? slave->Ins : slave->Smp))
+		if(dl != (bp == 0x32 ? slave->Nte : bp == 0x33 ? slave->Ins : slave->Smp))
 			continue;
 
 		// New note is a MIDI?


### PR DESCRIPTION
This might be the reason why you have several issues about stuck notes. Code is untested but the current code is obviously wrong and I compared this against the original assembly.